### PR TITLE
removed unsupported field in the card

### DIFF
--- a/template.go
+++ b/template.go
@@ -46,7 +46,6 @@ const inccidentTemplate = `{
             }
             ],
             "spacing": "Medium",
-            "height": "stretch",
             "horizontalAlignment": "Left",
             "style": "default"
           },
@@ -103,8 +102,7 @@ const inccidentTemplate = `{
                 }]
               }
 
-            ],
-            "height": "stretch"
+            ]
           }
           {{if (ne .MessageStatus "Resolved") }}
           ,
@@ -123,7 +121,6 @@ const inccidentTemplate = `{
                     "wrap": true,
                     "color": "Attention",
                     "separator": true,
-                    "height": "stretch",
                     "horizontalAlignment": "Left",
                     "size": "Small"
                   }]


### PR DESCRIPTION
This pr fixes the card. It removes the ```height``` field, which is apparently not supported anymore by webexapi
```
Response Info:
Status Code: 400
Status     : 400 Bad Request
Time       : 1.204858375s
Received At: 2021-03-17 15:21:39.528128597 +0000 UTC m=+1.212143749
Body       :
 {"message":"Card contains an unsupported property: \"height\" attribute in \"ColumnSet\" element.","errors":[{"description":"Card contains an unsupported property: \"height\" attribute in \"ColumnSet\" element."}],"trackingId":"ROUTER_60521E82-793F-01BB-03D1-AD26DC3B03D1"}
 ```